### PR TITLE
Edit post tags

### DIFF
--- a/web/resources/js/components/PostDisplay.vue
+++ b/web/resources/js/components/PostDisplay.vue
@@ -19,8 +19,12 @@ export default {
         return {
             comment_editor_visible: false,
             post_editor_visible: false,
+            tag_editor_visible: false,
             edited_post_body: null,
+            edited_post_tag: null,
+            edited_tag: null,
             edit_save_pending: false,
+            tag_save_pending: false,
             pin_pending: false,
             lock_pending: false,
             post_loaded: false,
@@ -36,6 +40,11 @@ export default {
         },
         can_edit() {
             return this.post.author_user_id === this.$store.getters.user.id
+                && !this.course_is_closed
+        },
+        can_edit_tag() {
+            return this.user_is_teacher
+                && this.post.author_user_id !== this.$store.getters.user.id
                 && !this.course_is_closed
         },
         can_delete() {
@@ -64,6 +73,14 @@ export default {
             let user_is_teacher = this.$store.getters.user.role === 'teacher'
             let post_tags = this.$store.getters.course_summary.post_tags
                 .filter(t => {return user_is_teacher || !t.teacher_only})
+                .map(t => {return { value: t.name, text: t.name }})
+            post_tags.unshift({ value: null, text: '(no tag)' })
+            return post_tags;
+        },
+        edit_tag_options() {
+            let author_is_teacher = this.post.author_user_role === 'teacher'
+            let post_tags = this.$store.getters.course_summary.post_tags
+                .filter(t => {return author_is_teacher || !t.teacher_only})
                 .map(t => {return { value: t.name, text: t.name }})
             post_tags.unshift({ value: null, text: '(no tag)' })
             return post_tags;
@@ -105,7 +122,6 @@ export default {
             this.post_editor_visible = true;
             this.comment_editor_visible = false;
             this.edited_post_body = "" + this.post.body; //copy
-            // include tag if post has one
             this.edited_post_tag = this.post.tag;
         },
         close_post_editor() {
@@ -113,9 +129,19 @@ export default {
         },
         handle_close_post_editor_ok() {
             this.edited_post_body = null;
-            this.edited_post_tag - null;
+            this.edited_post_tag = null;
             this.post_editor_visible = false;
+            this.edited_tag = null;
+            this.tag_editor_visible = false;
             this.$refs['abandon_post'].hide();
+        },
+        open_tag_editor() {
+            this.tag_editor_visible = true;
+            this.comment_editor_visible = false;
+            this.edited_tag = this.post.tag;
+        },
+        close_tag_editor() {
+            this.$refs['abandon_post'].show();
         },
         async save_post() {
             if (!this.$refs['postEditor'].hasContents()) {
@@ -132,6 +158,15 @@ export default {
             })
             this.post_editor_visible = false;
             this.edit_save_pending = false;
+        },
+        async save_tag() {
+            this.tag_save_pending = true;
+            await this.$store.dispatch('editTag', {
+                post_id: this.post_id,
+                tag: this.edited_tag,
+            })
+            this.tag_editor_visible = false;
+            this.tag_save_pending = false;
         },
         switch_screen() {
             if (this.$store.getters.mobile) {
@@ -231,6 +266,12 @@ export default {
                                 v-show="can_edit"
                             >Edit</button>
                             <button
+                                @click="open_tag_editor()"
+                                class="dropdown-item"
+                                type="button"
+                                v-show="can_edit_tag"
+                            >Edit tag</button>
+                            <button
                                 @click="remove()"
                                 class="dropdown-item"
                                 type="button"
@@ -240,6 +281,30 @@ export default {
                     </div>
                 </div>
 
+                <div v-if="tag_editor_visible">
+                    <fieldset v-bind:disabled="tag_save_pending">
+                    <div>
+                        <label for="post-tag">Tag post as:</label>
+                        <select class="form-select" v-model="edited_tag">
+                            <option v-for="option in edit_tag_options" :key="option.value" :value="option.value">
+                                {{ option.text }}
+                            </option>
+                        </select>
+                    </div>
+                    <div class="btn-groups">
+                        <div class="left"></div>
+                        <div class="right">
+                            <button
+                                class="btn btn-tertiary me-1"
+                                @click="close_tag_editor()">Cancel</button>
+                            <button
+                                class="btn btn-secondary"
+                                @click="save_tag()"
+                            ><font-awesome-icon v-if="tag_save_pending" icon="spinner" spin /> Save tag</button>
+                        </div>
+                    </div>
+                    </fieldset>
+                </div>
                 <div v-if="post_editor_visible">
                     <fieldset v-bind:disabled="edit_save_pending">
                     <div>

--- a/web/resources/js/components/PostDisplay.vue
+++ b/web/resources/js/components/PostDisplay.vue
@@ -70,20 +70,10 @@ export default {
             return this.$store.getters.mobile;
         },
         post_tag_options() {
-            let user_is_teacher = this.$store.getters.user.role === 'teacher'
-            let post_tags = this.$store.getters.course_summary.post_tags
-                .filter(t => {return user_is_teacher || !t.teacher_only})
-                .map(t => {return { value: t.name, text: t.name }})
-            post_tags.unshift({ value: null, text: '(no tag)' })
-            return post_tags;
+            return this.get_tags_available_for_role(this.$store.getters.user.role);
         },
         edit_tag_options() {
-            let author_is_teacher = this.post.author_user_role === 'teacher'
-            let post_tags = this.$store.getters.course_summary.post_tags
-                .filter(t => {return author_is_teacher || !t.teacher_only})
-                .map(t => {return { value: t.name, text: t.name }})
-            post_tags.unshift({ value: null, text: '(no tag)' })
-            return post_tags;
+            return this.get_tags_available_for_role(this.post.author_user_role);
         },
     },
     methods: {
@@ -176,6 +166,13 @@ export default {
                     view_post_create: false,
                 })
             }
+        },
+        get_tags_available_for_role(role) {
+            let post_tags = this.$store.getters.course_summary.post_tags
+               .filter(t => {return role === 'teacher' || !t.teacher_only})
+               .map(t => {return { value: t.name, text: t.name }})
+            post_tags.unshift({ value: null, text: '(no tag)' })
+            return post_tags;
         },
     },
     async mounted() {

--- a/web/resources/js/store.js
+++ b/web/resources/js/store.js
@@ -137,12 +137,16 @@ const mutations = {
     state.currently_viewed_post = payload
   },
   editPost (state, payload) {
+    console.log("edit post in store");
+    console.log(payload);
     let post_id = payload.post_id
     let body = payload.body
+    let tag = payload.tag
     let edited_at = payload.edited_at
 
     if (state.currently_viewed_post.id === post_id) {
       state.currently_viewed_post.body = body
+      state.currently_viewed_post.tag = tag
       state.currently_viewed_post.edited_at = edited_at
     }
   },
@@ -287,7 +291,12 @@ const actions = {
   },
   async editPost ({ commit }, payload) {
     let response = await axios.post('/api/course/' + this.state.user.course_id + '/post/' + payload.post_id, payload)
-    commit('editPost', { post_id: payload.post_id, body: payload.body, edited_at: response.data.edited_at })
+    commit('editPost', { post_id: payload.post_id, body: payload.body, tag: payload.tag, edited_at: response.data.edited_at })
+    return response.data
+  },
+  async editTag ({ commit }, payload) {
+    let response = await axios.post('/api/course/' + this.state.user.course_id + '/post/' + payload.post_id + '/tag', payload)
+    commit('editPost', { post_id: payload.post_id, tag: payload.tag, edited_at: response.data.edited_at })
     return response.data
   },
   async pinPost ({ commit }, payload) {

--- a/web/resources/js/store.js
+++ b/web/resources/js/store.js
@@ -137,12 +137,13 @@ const mutations = {
     state.currently_viewed_post = payload
   },
   editPost (state, payload) {
-    console.log("edit post in store");
-    console.log(payload);
     let post_id = payload.post_id
     let body = payload.body
     let tag = payload.tag
     let edited_at = payload.edited_at
+
+    let edited_post = state.posts.findIndex(post => post.id === post_id);
+    state.posts[edited_post].tag = tag;
 
     if (state.currently_viewed_post.id === post_id) {
       state.currently_viewed_post.body = body

--- a/web/routes/api.php
+++ b/web/routes/api.php
@@ -24,6 +24,7 @@ Route::get('/course/{course_id}/posts', [ApiController::class, 'getCoursePosts']
 Route::get('/course/{course_id}/post/{post_id}', [ApiController::class, 'getPost']);
 Route::post('/course/{course_id}/post/new', [ApiController::class, 'createPost']);
 Route::post('/course/{course_id}/post/{post_id}', [ApiController::class, 'editPost']);
+Route::post('/course/{course_id}/post/{post_id}/tag', [ApiController::class, 'editTag']);
 Route::delete('/course/{course_id}/post/{post_id}', [ApiController::class, 'deletePost']);
 Route::post('/course/{course_id}/post/{post_id}/pin/{pinned}', [ApiController::class, 'pinPost']);
 Route::post('/course/{course_id}/post/{post_id}/lock/{locked}', [ApiController::class, 'lockPost']);
@@ -33,4 +34,3 @@ Route::post('/course/{course_id}/comment/{comment_id}/endorse/{endorsed}', [ApiC
 Route::post('/course/{course_id}/comment/{comment_id}/mute/{muted}', [ApiController::class, 'muteComment']);
 Route::post('/course/{course_id}/comment/{comment_id}/upvote/{upvoted}', [ApiController::class, 'upvoteComment']);
 Route::post('/course/{course_id}/upload_file', [ApiController::class, 'uploadFile']);
-


### PR DESCRIPTION
- anyone can edit tags on their own posts with the regular edit feature
- teachers can edit tags on other posts (student or teacher)
- when teachers edit tags on posts they did not author, they are limited by the post author's role (this is different than what I planned. it looked like editing posts from the student side was going to be complicated if a teacher tagged their post with a teacher-only tag)  maybe we can decide together if it's worth the effort to let teachers use any tag on student posts

PostList.vue shows the list of all posts, this is where the tag-badge needs to be updated after a post's tags have been updated

PostDisplay.vue has new pieces that track closely with the post edit feature already in place. can_edit_tag is a new computed prop for ability to edit just tags, open_tag_editor and tag_save_pending handle the form display, and edit_tag_options filters available tags based on author's role (see the note above, we may decide to do this differently)
handle_close_post_editor_ok was already handling clearing out the form data for the edit post form, this now also clears out the tag edit form

store.js has a new editTag action that calls the new route in api.php, this gets the ApiController function editTag (little bit of different auth logic than the existing editPost handler)